### PR TITLE
Support for sreamed output

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -11,6 +11,8 @@ use Spiral\Goridge\Exception\InvalidArgumentException;
  * @psalm-type FrameType = Frame::CONTROL | Frame::ERROR
  * @psalm-type FrameCodec = Frame::CODEC_*
  * @psalm-type FrameCodecValue = int-mask-of<FrameCodec>
+ * @psalm-type FrameByte10 = Frame::BYTE10_*
+ * @psalm-type FrameByte10Value = int-mask-of<FrameByte10>
  */
 final class Frame
 {
@@ -49,12 +51,12 @@ final class Frame
     /**#@-*/
 
     /**#@+
-     * BYTE flags, it means, that we can set multiply flags from this group
+     * BYTE10 flags, it means, that we can set multiply flags from this group
      * using bitwise OR.
      *
      * @var positive-int Flags for {@see $byte10}
      */
-    public const CONNECTION_CHUNKED_OUT = 0x01;
+    public const BYTE10_STREAM = 0x01;
     /**#@-*/
 
     /**
@@ -67,25 +69,26 @@ final class Frame
      */
     public array $options = [];
 
-    /**
-     * @var int
-     */
     public int $flags;
 
-    public int $byte10 = 0;
+    /**
+     * @psalm-var FrameByte10Value
+     */
+    public int $byte10;
 
     public int $byte11 = 0;
 
     /**
-     * @param string|null $body
      * @param array<int> $options
-     * @param int $flags
+     *
+     * @psalm-param FrameByte10Value $byte10
      */
-    public function __construct(?string $body, array $options = [], int $flags = 0)
+    public function __construct(?string $body, array $options = [], int $flags = 0, int $byte10 = 0)
     {
         $this->payload = $body;
         $this->options = $options;
         $this->flags = $flags;
+        $this->byte10 = $byte10;
     }
 
     /**

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -74,21 +74,18 @@ final class Frame
     /**
      * @psalm-var FrameByte10Value
      */
-    public int $byte10;
+    public int $byte10 = 0;
 
     public int $byte11 = 0;
 
     /**
      * @param array<int> $options
-     *
-     * @psalm-param FrameByte10Value $byte10
      */
-    public function __construct(?string $body, array $options = [], int $flags = 0, int $byte10 = 0)
+    public function __construct(?string $body, array $options = [], int $flags = 0)
     {
         $this->payload = $body;
         $this->options = $options;
         $this->flags = $flags;
-        $this->byte10 = $byte10;
     }
 
     /**

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -48,6 +48,15 @@ final class Frame
     public const CODEC_PROTO   = 0x80;
     /**#@-*/
 
+    /**#@+
+     * BYTE flags, it means, that we can set multiply flags from this group
+     * using bitwise OR.
+     *
+     * @var positive-int Flags for {@see $byte10}
+     */
+    public const CONNECTION_CHUNKED_OUT = 0x01;
+    /**#@-*/
+
     /**
      * @var string|null
      */
@@ -62,6 +71,10 @@ final class Frame
      * @var int
      */
     public int $flags;
+
+    public int $byte10 = 0;
+
+    public int $byte11 = 0;
 
     /**
      * @param string|null $body
@@ -85,7 +98,7 @@ final class Frame
                 throw new InvalidArgumentException('Flags can be byte only');
             }
 
-            $this->flags = $this->flags | $f;
+            $this->flags |= $f;
         }
     }
 
@@ -117,17 +130,17 @@ final class Frame
      */
     public static function packFrame(Frame $frame): string
     {
-        $header = pack(
+        $header = \pack(
             'CCL',
-            self::VERSION << 4 | (count($frame->options) + 3),
+            self::VERSION << 4 | (\count($frame->options) + 3),
             $frame->flags,
-            strlen((string)$frame->payload)
+            \strlen((string)$frame->payload)
         );
 
         if ($frame->options !== []) {
-            $header .= pack('LCCL*', crc32($header), 0, 0, ...$frame->options);
+            $header .= \pack('LCCL*', \crc32($header), $frame->byte10, $frame->byte11, ...$frame->options);
         } else {
-            $header .= pack('LCC', crc32($header), 0, 0);
+            $header .= \pack('LCC', \crc32($header), $frame->byte10, $frame->byte11);
         }
 
         return $header . (string)$frame->payload;
@@ -157,7 +170,7 @@ final class Frame
      */
     public static function initFrame(array $header, string $body): Frame
     {
-        assert(count($header) >= 2);
+        \assert(\count($header) >= 2);
 
         /**
          * optimize?

--- a/tests/Goridge/FrameTest.php
+++ b/tests/Goridge/FrameTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Goridge;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Goridge\Frame;
+
+class FrameTest extends TestCase
+{
+    public function testByte10DefaultValue(): void
+    {
+        $frame = new Frame('');
+        $this->assertSame(0, $frame->byte10);
+    }
+
+    public function testByte10DefaultValuePacked(): void
+    {
+        $string = Frame::packFrame(new Frame(''));
+        $this->assertSame(\chr(0), $string[10]);
+    }
+
+    public function testByte10StreamedOutputPacked(): void
+    {
+        $frame = new Frame('');
+        $frame->byte10 = Frame::BYTE10_STREAM;
+        $string = Frame::packFrame($frame);
+        $this->assertSame(Frame::BYTE10_STREAM, \ord($string[10]));
+    }
+}

--- a/tests/Goridge/MsgPackRPCTest.php
+++ b/tests/Goridge/MsgPackRPCTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Spiral\Goridge\Tests;
 
 use Spiral\Goridge\RPC\Codec\MsgpackCodec;
-use Spiral\Goridge\RPC\Exception\CodecException;
 use Spiral\Goridge\RPC\Exception\ServiceException;
 use Spiral\Goridge\RPC\RPC;
 


### PR DESCRIPTION
Added configurable `byte10` property and `Frame::BYTE10_STREAM` constant into the Frame class

Fix #11