### PR TITLE
Add ServiceException to PHPDoc

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,7 +14,5 @@ jobs:
       test-server: true
       os: >-
         ['ubuntu-latest']
-      php: >-
-        ['8.1', '8.2']
       stability: >-
         ['prefer-lowest', 'prefer-stable']

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -14,4 +14,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.1']
+        ['8.3']

--- a/src/RPC/RPCInterface.php
+++ b/src/RPC/RPCInterface.php
@@ -6,6 +6,7 @@ namespace Spiral\Goridge\RPC;
 
 use Spiral\Goridge\Exception\GoridgeException;
 use Spiral\Goridge\RPC\Exception\RPCException;
+use Spiral\Goridge\RPC\Exception\ServiceException;
 
 interface RPCInterface
 {
@@ -31,6 +32,7 @@ interface RPCInterface
      *
      * @throws GoridgeException
      * @throws RPCException
+     * @throws ServiceException
      */
     public function call(string $method, mixed $payload, mixed $options = null): mixed;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ❌ 
| Issues        | https://github.com/roadrunner-php/issues/issues/12

### What was changed

1. The missing `Spiral\Goridge\RPC\Exception\ServiceException` has been added to the PHPDoc. It is thrown in this method:
https://github.com/roadrunner-php/goridge/blob/4.x/src/RPC/RPC.php#L101
2. In the Psalm GitHub Action, the PHP version has been updated to 8.3. In the PHPUnit GitHub Action, the PHP versions have been removed to use the default versions (8.1-8.3)
