### PR TITLE
feat: Implement "Async" RPC

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     "scripts": {
         "test": "phpunit --no-coverage --colors=always",
         "test-cover": "phpunit --coverage-clover=coverage.xml",
-        "test-static": "psalm",
+        "test-static": "psalm --no-cache",
         "test-mutations": "infection"
     },
     "minimum-stability": "dev",

--- a/src/ConnectedRelayInterface.php
+++ b/src/ConnectedRelayInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spiral\Goridge;
+
+use Spiral\Goridge\Exception\RelayException;
+
+/**
+ * This interface describes a Relay that explictily establishes a connection.
+ * That connection can also be re-established on the fly (in comparison to StreamRelay, which relies on the existence of the streams).
+ * The object is also clonable, i.e. supports cloning without data errors due to shared state.
+ */
+interface ConnectedRelayInterface
+{
+    /**
+     * Returns true if the underlying connection is already established
+     */
+    public function isConnected(): bool;
+
+    /**
+     * Establishes the underlying connection and returns true on success, false on failure, or throws an exception in case of an error.
+     *
+     * @throws RelayException
+     */
+    public function connect(): bool;
+
+    /**
+     * Closes the underlying connection.
+     */
+    public function close(): void;
+}

--- a/src/ConnectedRelayInterface.php
+++ b/src/ConnectedRelayInterface.php
@@ -9,7 +9,7 @@ use Spiral\Goridge\Exception\RelayException;
  * That connection can also be re-established on the fly (in comparison to StreamRelay, which relies on the existence of the streams).
  * The object is also clonable, i.e. supports cloning without data errors due to shared state.
  */
-interface ConnectedRelayInterface
+interface ConnectedRelayInterface extends RelayInterface
 {
     /**
      * Returns true if the underlying connection is already established

--- a/src/ConnectedRelayInterface.php
+++ b/src/ConnectedRelayInterface.php
@@ -27,4 +27,9 @@ interface ConnectedRelayInterface extends RelayInterface
      * Closes the underlying connection.
      */
     public function close(): void;
+
+    /**
+     * Enforce implementation of __clone magic method
+     */
+    public function __clone();
 }

--- a/src/MultiRelayHelper.php
+++ b/src/MultiRelayHelper.php
@@ -89,7 +89,7 @@ class MultiRelayHelper
     }
 
     /**
-     * @param array<array-key, RelayInterface> $relays
+     * @param array<array-key, ConnectedRelayInterface> $relays
      * @return array-key[]|false
      * @internal
      * Returns either
@@ -98,14 +98,14 @@ class MultiRelayHelper
      */
     public static function checkConnected(array $relays): array|false
     {
-        if (count($relays) === 0 || !$relays[array_key_first($relays)] instanceof SocketRelay) {
+        if (count($relays) === 0) {
             return false;
         }
 
         $keysNotConnected = [];
         foreach ($relays as $key => $relay) {
-            assert($relay instanceof SocketRelay);
-            if ($relay->socket === null) {
+            assert($relay instanceof ConnectedRelayInterface);
+            if (!$relay->isConnected()) {
                 $relay->connect();
                 $keysNotConnected[] = $key;
             }

--- a/src/MultiRelayHelper.php
+++ b/src/MultiRelayHelper.php
@@ -33,7 +33,7 @@ class MultiRelayHelper
                 // A non-connected relay implies that it is free. We can eat the connection-cost if it means
                 // we'll have more Relays available.
                 // Not doing this would also potentially result in never using the relay in the first place.
-                if($relay->socket === null){
+                if ($relay->socket === null) {
                     return $index;
                 }
 

--- a/src/MultiRelayHelper.php
+++ b/src/MultiRelayHelper.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Spiral\Goridge;
 
 use Spiral\Goridge\RPC\Exception\RPCException;
-use function socket_select;
 
 class MultiRelayHelper
 {
@@ -19,15 +18,15 @@ class MultiRelayHelper
      */
     public static function findRelayWithMessage(array $relays, int $timeoutInMicroseconds = 0): array|false
     {
-        if (count($relays) === 0) {
+        if (\count($relays) === 0) {
             return false;
         }
 
-        if ($relays[array_key_first($relays)] instanceof SocketRelay) {
+        if ($relays[\array_key_first($relays)] instanceof SocketRelay) {
             $sockets = [];
             $socketIdToRelayIndexMap = [];
             foreach ($relays as $relayIndex => $relay) {
-                assert($relay instanceof SocketRelay);
+                \assert($relay instanceof SocketRelay);
 
                 // Enforce connection
                 if ($relay->socket === null) {
@@ -36,34 +35,34 @@ class MultiRelayHelper
                 }
 
                 $sockets[] = $relay->socket;
-                $socketIdToRelayIndexMap[spl_object_id($relay->socket)] = $relayIndex;
+                $socketIdToRelayIndexMap[\spl_object_id($relay->socket)] = $relayIndex;
             }
 
-            if (count($sockets) === 0) {
+            if (\count($sockets) === 0) {
                 return false;
             }
 
             $writes = null;
             $except = null;
-            $changes = socket_select($sockets, $writes, $except, 0, $timeoutInMicroseconds);
+            $changes = \socket_select($sockets, $writes, $except, 0, $timeoutInMicroseconds);
 
             if ($changes > 0) {
                 $indexes = [];
                 foreach ($sockets as $socket) {
-                    $indexes[] = $socketIdToRelayIndexMap[spl_object_id($socket)] ?? throw new RPCException("Invalid socket??");
+                    $indexes[] = $socketIdToRelayIndexMap[\spl_object_id($socket)] ?? throw new RPCException("Invalid socket??");
                 }
 
                 return $indexes;
-            } else {
-                return false;
             }
+
+            return false;
         }
 
-        if ($relays[array_key_first($relays)] instanceof StreamRelay) {
+        if ($relays[\array_key_first($relays)] instanceof StreamRelay) {
             $streams = [];
             $streamNameToRelayIndexMap = [];
             foreach ($relays as $relayIndex => $relay) {
-                assert($relay instanceof StreamRelay);
+                \assert($relay instanceof StreamRelay);
 
                 $streams[] = $relay->in;
                 $streamNameToRelayIndexMap[(string)$relay->in] = $relayIndex;
@@ -71,7 +70,7 @@ class MultiRelayHelper
 
             $writes = null;
             $except = null;
-            $changes = stream_select($streams, $writes, $except, 0, $timeoutInMicroseconds);
+            $changes = \stream_select($streams, $writes, $except, 0, $timeoutInMicroseconds);
 
             if ($changes > 0) {
                 $indexes = [];
@@ -80,9 +79,9 @@ class MultiRelayHelper
                 }
 
                 return $indexes;
-            } else {
-                return false;
             }
+
+            return false;
         }
 
         return false;
@@ -98,13 +97,13 @@ class MultiRelayHelper
      */
     public static function checkConnected(array $relays): array|false
     {
-        if (count($relays) === 0) {
+        if (\count($relays) === 0) {
             return false;
         }
 
         $keysNotConnected = [];
         foreach ($relays as $key => $relay) {
-            assert($relay instanceof ConnectedRelayInterface);
+            \assert($relay instanceof ConnectedRelayInterface);
             if (!$relay->isConnected()) {
                 $relay->connect();
                 $keysNotConnected[] = $key;

--- a/src/MultiRelayHelper.php
+++ b/src/MultiRelayHelper.php
@@ -18,7 +18,7 @@ class MultiRelayHelper
      *  - an array of indices if multiple
      *  - or false if none
      */
-    public static function findRelayWithMessage(array $relays): array|bool|int
+    public static function findRelayWithMessage(array $relays, int $timeoutInMicroseconds = 0): array|bool|int
     {
         if (count($relays) === 0) {
             return false;
@@ -44,7 +44,7 @@ class MultiRelayHelper
             $socketIds = array_flip(array_map(fn(Socket $socket) => spl_object_id($socket), $sockets));
             $writes = null;
             $except = null;
-            $changes = socket_select($sockets, $writes, $except, 0);
+            $changes = socket_select($sockets, $writes, $except, 0, $timeoutInMicroseconds);
 
             if ($changes > 1) {
                 return array_map(fn(Socket $socket) => $socketIds[spl_object_id($socket)], $sockets);
@@ -67,7 +67,7 @@ class MultiRelayHelper
             $streamIds = array_flip(array_map(fn($resource) => (string)$resource, $streams));
             $writes = null;
             $except = null;
-            $changes = stream_select($streams, $writes, $except, 0);
+            $changes = stream_select($streams, $writes, $except, 0, $timeoutInMicroseconds);
 
             if ($changes > 1) {
                 return array_map(fn($resource) => $streamIds[(string)$resource], $streams);

--- a/src/MultiRelayHelper.php
+++ b/src/MultiRelayHelper.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Goridge;
+
+use Socket;
+use function socket_select;
+
+class MultiRelayHelper
+{
+    /**
+     * @internal
+     * Returns either
+     *  - a single index if only one relay has changed state
+     *  - an array of indices if multiple
+     *  - or false if none
+     * @param RelayInterface[] $relays
+     * @return int|array|false
+     */
+    public static function findRelayWithMessage(array $relays): int|array|false
+    {
+        if (count($relays) === 0) {
+            return false;
+        }
+
+        if ($relays[0] instanceof SocketRelay) {
+            $sockets = array_map(fn(SocketRelay $relay) => $relay->socket, $relays);
+            // Map of "id" => index
+            $socketIds = array_flip(array_map(fn(Socket $socket) => spl_object_id($socket), $sockets));
+            $writes = null;
+            $except = null;
+            $changes = socket_select($sockets, $writes, $except, 0);
+
+            if ($changes > 1) {
+                return array_map(fn(Socket $socket) => $socketIds[spl_object_id($socket)], $sockets);
+            } elseif ($changes === 1) {
+                $id = spl_object_id($sockets[0]);
+                return $socketIds[$id];
+            } else {
+                return false;
+            }
+        }
+
+        if ($relays[0] instanceof StreamRelay) {
+            /** @var resource[] $streams */
+            $streams = array_map(fn(StreamRelay $relay) => $relay->in, $relays);
+            // Map of "id" => index
+            $streamIds = array_flip(array_map(fn($resource) => (string)$resource, $streams));
+            $writes = null;
+            $except = null;
+            $changes = stream_select($streams, $writes, $except, 0);
+
+            if ($changes > 1) {
+                return array_map(fn($resource) => $streamIds[(string)$resource], $streams);
+            } elseif ($changes === 1) {
+                $id = (string)$streams[0];
+                return $streamIds[$id];
+            } else {
+                return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/RPC/AbstractRPC.php
+++ b/src/RPC/AbstractRPC.php
@@ -7,11 +7,6 @@ namespace Spiral\Goridge\RPC;
 use Spiral\Goridge\Frame;
 use Spiral\Goridge\RelayInterface;
 use Spiral\Goridge\RPC\Exception\ServiceException;
-use Stringable;
-use function sprintf;
-use function strlen;
-use function substr;
-use function ucfirst;
 
 abstract class AbstractRPC implements RPCInterface
 {
@@ -28,15 +23,14 @@ abstract class AbstractRPC implements RPCInterface
     protected static int $seq = 1;
 
     public function __construct(
-        protected CodecInterface $codec
-    )
-    {
+        protected CodecInterface $codec,
+    ) {
     }
 
     /**
      * @psalm-pure
      */
-    public function withServicePrefix(string $service): self
+    public function withServicePrefix(string $service): static
     {
         /** @psalm-suppress ImpureVariable */
         $rpc = clone $this;
@@ -63,14 +57,14 @@ abstract class AbstractRPC implements RPCInterface
     protected function decodeResponse(Frame $frame, RelayInterface $relay, mixed $options = null): mixed
     {
         // exclude method name
-        $body = substr((string)$frame->payload, $frame->options[1]);
+        $body = \substr((string)$frame->payload, $frame->options[1]);
 
         if ($frame->hasFlag(Frame::ERROR)) {
-            $name = $relay instanceof Stringable
+            $name = $relay instanceof \Stringable
                 ? (string)$relay
                 : $relay::class;
 
-            throw new ServiceException(sprintf("Error '%s' on %s", $body, $name));
+            throw new ServiceException(\sprintf("Error '%s' on %s", $body, $name));
         }
 
         return $this->codec->decode($body, $options);
@@ -82,10 +76,10 @@ abstract class AbstractRPC implements RPCInterface
     protected function packFrame(string $method, mixed $payload): Frame
     {
         if ($this->service !== null) {
-            $method = $this->service . '.' . ucfirst($method);
+            $method = $this->service . '.' . \ucfirst($method);
         }
 
         $body = $method . $this->codec->encode($payload);
-        return new Frame($body, [self::$seq, strlen($method)], $this->codec->getIndex());
+        return new Frame($body, [self::$seq, \strlen($method)], $this->codec->getIndex());
     }
 }

--- a/src/RPC/AbstractRPC.php
+++ b/src/RPC/AbstractRPC.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Goridge\RPC;
+
+use Spiral\Goridge\Frame;
+use Spiral\Goridge\RelayInterface;
+use Spiral\Goridge\RPC\Exception\ServiceException;
+use Stringable;
+use function sprintf;
+use function strlen;
+use function substr;
+use function ucfirst;
+
+abstract class AbstractRPC implements RPCInterface
+{
+    /**
+     * RPC calls service prefix.
+     *
+     * @var non-empty-string|null
+     */
+    protected ?string $service = null;
+
+    /**
+     * @var positive-int
+     */
+    protected static int $seq = 1;
+
+    public function __construct(
+        protected CodecInterface $codec
+    )
+    {
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public function withServicePrefix(string $service): RPCInterface
+    {
+        /** @psalm-suppress ImpureVariable */
+        $rpc = clone $this;
+        $rpc->service = $service;
+
+        return $rpc;
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public function withCodec(CodecInterface $codec): RPCInterface
+    {
+        /** @psalm-suppress ImpureVariable */
+        $rpc = clone $this;
+        $rpc->codec = $codec;
+
+        return $rpc;
+    }
+
+    /**
+     * @throws Exception\ServiceException
+     */
+    protected function decodeResponse(Frame $frame, RelayInterface $relay, mixed $options = null): mixed
+    {
+        // exclude method name
+        $body = substr((string)$frame->payload, $frame->options[1]);
+
+        if ($frame->hasFlag(Frame::ERROR)) {
+            $name = $relay instanceof Stringable
+                ? (string)$relay
+                : $relay::class;
+
+            throw new ServiceException(sprintf("Error '%s' on %s", $body, $name));
+        }
+
+        return $this->codec->decode($body, $options);
+    }
+
+    /**
+     * @param non-empty-string $method
+     */
+    protected function packFrame(string $method, mixed $payload): Frame
+    {
+        if ($this->service !== null) {
+            $method = $this->service . '.' . ucfirst($method);
+        }
+
+        $body = $method . $this->codec->encode($payload);
+        return new Frame($body, [self::$seq, strlen($method)], $this->codec->getIndex());
+    }
+}

--- a/src/RPC/AbstractRPC.php
+++ b/src/RPC/AbstractRPC.php
@@ -36,7 +36,7 @@ abstract class AbstractRPC implements RPCInterface
     /**
      * @psalm-pure
      */
-    public function withServicePrefix(string $service): RPCInterface
+    public function withServicePrefix(string $service): self
     {
         /** @psalm-suppress ImpureVariable */
         $rpc = clone $this;
@@ -48,7 +48,7 @@ abstract class AbstractRPC implements RPCInterface
     /**
      * @psalm-pure
      */
-    public function withCodec(CodecInterface $codec): RPCInterface
+    public function withCodec(CodecInterface $codec): self
     {
         /** @psalm-suppress ImpureVariable */
         $rpc = clone $this;

--- a/src/RPC/AsyncRPCInterface.php
+++ b/src/RPC/AsyncRPCInterface.php
@@ -3,6 +3,7 @@
 namespace Spiral\Goridge\RPC;
 
 use Spiral\Goridge\Exception\GoridgeException;
+use Spiral\Goridge\Exception\RelayException;
 use Spiral\Goridge\RPC\Exception\RPCException;
 use Spiral\Goridge\RPC\Exception\ServiceException;
 
@@ -36,28 +37,33 @@ interface AsyncRPCInterface extends RPCInterface
     public function hasResponse(int $seq): bool;
 
     /**
-     * Checks the "ID"s obtained through @see AsyncRPCInterface::callAsync() if any of them got a response yet.
+     * Checks the "ID"s obtained through @see AsyncRPCInterface::callAsync() if they've got a response yet.
      * Returns an array of "ID"s that do.
      *
      * @param positive-int[] $seqs
      * @return positive-int[]
      */
-    public function hasAnyResponse(array $seqs): array;
+    public function hasResponses(array $seqs): array;
 
     /**
      * Fetch the response for the "ID" obtained through @see AsyncRPCInterface::callAsync() .
      * @param positive-int $seq
      * @throws RPCException
      * @throws ServiceException
+     * @throws RelayException
      */
     public function getResponse(int $seq, mixed $options = null): mixed;
 
     /**
      * Fetches the responses for the "ID"s obtained through @see AsyncRPCInterface::callAsync()
      * and returns a map of "ID" => Response.
+     * @throws RelayException
+     * @throws ServiceException
+     * @throws RPCException
      *
      * @param array<array-key, positive-int> $seqs
      * @return iterable<positive-int, mixed>
+     *
      */
     public function getResponses(array $seqs, mixed $options = null): iterable;
 }

--- a/src/RPC/AsyncRPCInterface.php
+++ b/src/RPC/AsyncRPCInterface.php
@@ -46,8 +46,18 @@ interface AsyncRPCInterface extends RPCInterface
 
     /**
      * Fetch the response for the "ID" obtained through @see AsyncRPCInterface::callAsync() .
+     * @param positive-int $seq
      * @throws RPCException
      * @throws ServiceException
      */
     public function getResponse(int $seq, mixed $options = null): mixed;
+
+    /**
+     * Fetches the responses for the "ID"s obtained through @see AsyncRPCInterface::callAsync()
+     * and returns a map of "ID" => Response.
+     *
+     * @param array<array-key, positive-int> $seqs
+     * @return iterable<positive-int, mixed>
+     */
+    public function getResponses(array $seqs, mixed $options = null): iterable;
 }

--- a/src/RPC/AsyncRPCInterface.php
+++ b/src/RPC/AsyncRPCInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Spiral\Goridge\RPC;
+
+use Spiral\Goridge\Exception\GoridgeException;
+use Spiral\Goridge\RPC\Exception\RPCException;
+use Spiral\Goridge\RPC\Exception\ServiceException;
+
+interface AsyncRPCInterface extends RPCInterface
+{
+    /**
+     * Invoke remote RoadRunner service method using given payload (free form) non-blockingly and ignore the response.
+     *
+     * @param non-empty-string $method
+     *
+     * @throws GoridgeException
+     */
+    public function callIgnoreResponse(string $method, mixed $payload): void;
+
+    /**
+     * Invoke remote RoadRunner service method using given payload (free form) non-blockingly but accept a response.
+     *
+     * @param non-empty-string $method
+     * @return positive-int An "ID" to check whether a response has been received and to fetch said response.
+     *
+     * @throws GoridgeException
+     */
+    public function callAsync(string $method, mixed $payload): int;
+
+    /**
+     * Check whether a response has been received using the "ID" obtained through @see AsyncRPCInterface::callAsync() .
+     *
+     * @param positive-int $seq
+     * @return bool
+     */
+    public function hasResponse(int $seq): bool;
+
+    /**
+     * Checks the "ID"s obtained through @see AsyncRPCInterface::callAsync() if any of them got a response yet.
+     * Returns an array of "ID"s that do.
+     *
+     * @param positive-int[] $seqs
+     * @return positive-int[]
+     */
+    public function hasAnyResponse(array $seqs): array;
+
+    /**
+     * Fetch the response for the "ID" obtained through @see AsyncRPCInterface::callAsync() .
+     * @throws RPCException
+     * @throws ServiceException
+     */
+    public function getResponse(int $seq, mixed $options = null): mixed;
+}

--- a/src/RPC/MultiRPC.php
+++ b/src/RPC/MultiRPC.php
@@ -125,8 +125,8 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
     public function callIgnoreResponse(string $method, mixed $payload): void
     {
         $relay = $this->getNextFreeRelay();
-        $relay->send($this->packFrame($method, $payload));
         $this->occupiedRelaysIgnoreResponse[] = $relay;
+        $relay->send($this->packFrame($method, $payload));
         self::$seq++;
     }
 
@@ -138,11 +138,13 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
         }
 
         $relay = $this->getNextFreeRelay();
-        $relay->send($this->packFrame($method, $payload));
         $seq = self::$seq;
         self::$seq++;
         $this->occupiedRelays[$seq] = $relay;
         $this->seqToRelayMap[$seq] = $relay;
+
+        $relay->send($this->packFrame($method, $payload));
+
         return $seq;
     }
 

--- a/src/RPC/MultiRPC.php
+++ b/src/RPC/MultiRPC.php
@@ -295,7 +295,7 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
                 $indexKeyed = array_flip($index);
                 foreach ($this->occupiedRelaysIgnoreResponse as $relayIndex => $relay) {
                     if (isset($indexKeyed[$relayIndex])) {
-                        $this->tryFlushRelay($relay, true);
+                        $this->tryFlushRelay($relay);
                         $this->freeRelays[] = $relay;
                     } else {
                         $occupiedRelaysIgnoreResponse[] = $relay;
@@ -307,7 +307,7 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
             } elseif ($index !== false) {
                 /** @var RelayInterface $relay */
                 $relay = array_splice($this->occupiedRelaysIgnoreResponse, $index, 1)[0];
-                $this->tryFlushRelay($relay, true);
+                $this->tryFlushRelay($relay);
                 return $relay;
             }
         }
@@ -327,7 +327,7 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
                     // Wait for an ignore-response relay to become free (the oldest since it makes the most sense)
                     /** @var RelayInterface $relay */
                     $relay = array_shift($this->occupiedRelaysIgnoreResponse);
-                    $this->tryFlushRelay($relay, true);
+                    $this->tryFlushRelay($relay);
                     return $relay;
                 } else {
                     // Use the oldest occupied relay for this instead

--- a/src/RPC/MultiRPC.php
+++ b/src/RPC/MultiRPC.php
@@ -139,11 +139,12 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
 
         $relay = $this->getNextFreeRelay();
         $seq = self::$seq;
-        self::$seq++;
         $this->occupiedRelays[$seq] = $relay;
         $this->seqToRelayMap[$seq] = $relay;
 
         $relay->send($this->packFrame($method, $payload));
+
+        self::$seq++;
 
         return $seq;
     }

--- a/src/RPC/MultiRPC.php
+++ b/src/RPC/MultiRPC.php
@@ -47,6 +47,12 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
         array $relays,
         CodecInterface $codec = new JsonCodec()
     ) {
+        foreach ($relays as $relay) {
+            if (!($relay instanceof SocketRelay)) {
+                throw new RPCException("MultiRPC can only be used with sockets, no pipes allowed");
+            }
+        }
+
         $this->freeRelays = $relays;
         parent::__construct($codec);
     }

--- a/src/RPC/MultiRPC.php
+++ b/src/RPC/MultiRPC.php
@@ -10,7 +10,6 @@ use Spiral\Goridge\Exception\TransportException;
 use Spiral\Goridge\Frame;
 use Spiral\Goridge\MultiRelayHelper;
 use Spiral\Goridge\Relay;
-use Spiral\Goridge\RelayInterface;
 use Spiral\Goridge\RPC\Codec\JsonCodec;
 use Spiral\Goridge\RPC\Exception\RPCException;
 use Spiral\Goridge\SocketRelay;
@@ -61,9 +60,9 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
     public function __construct(
         array $relays,
         int $asyncBufferThreshold = self::DEFAULT_BUFFER_THRESHOLD,
-        CodecInterface $codec = new JsonCodec()
+        CodecInterface $codec = new JsonCodec(),
     ) {
-        if (count($relays) === 0) {
+        if (\count($relays) === 0) {
             throw new RPCException("MultiRPC needs at least one relay. Zero provided.");
         }
 

--- a/src/RPC/MultiRPC.php
+++ b/src/RPC/MultiRPC.php
@@ -273,6 +273,7 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
     private function ensureFreeRelayAvailable(): int
     {
         if (count($this->freeRelays) > 0) {
+            /** @psalm-return int */
             return array_key_last($this->freeRelays);
         }
 
@@ -300,6 +301,7 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
                 }
             }
 
+            assert(count($this->freeRelays) > 0);
             return array_key_last($this->freeRelays);
         }
 

--- a/src/RPC/MultiRPC.php
+++ b/src/RPC/MultiRPC.php
@@ -52,6 +52,21 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
     }
 
     /**
+     * Without cloning relays explicitly they get shared and thus, when one RPC gets called, the freeRelays array
+     * in the other RPC stays the same, making it reuse the just-used and still occupied relay.
+     */
+    public function __clone()
+    {
+        foreach ($this->freeRelays as $key => $relay) {
+            $this->freeRelays[$key] = clone $relay;
+        }
+        foreach ($this->occupiedRelays as $key => $relay) {
+            $this->occupiedRelays[$key] = clone $relay;
+        }
+        $this->seqToRelayMap = $this->asyncResponseBuffer = [];
+    }
+
+    /**
      * @param non-empty-string $connection
      * @param positive-int $count
      */

--- a/src/RPC/MultiRPC.php
+++ b/src/RPC/MultiRPC.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Goridge\RPC;
+
+use RuntimeException;
+use Spiral\Goridge\Frame;
+use Spiral\Goridge\MultiRelayHelper;
+use Spiral\Goridge\Relay;
+use Spiral\Goridge\RelayInterface;
+use Spiral\Goridge\RPC\Codec\JsonCodec;
+use Spiral\Goridge\RPC\Exception\RPCException;
+use Spiral\Goridge\SocketRelay;
+
+class MultiRPC extends AbstractRPC implements AsyncRPCInterface
+{
+    /**
+     * @var RelayInterface[]
+     */
+    private array $freeRelays = [];
+
+    /**
+     * @var RelayInterface[]
+     */
+    private array $occupiedRelays = [];
+
+    /**
+     * @var RelayInterface[]
+     */
+    private array $occupiedRelaysIgnoreResponse = [];
+
+    /**
+     * @var array<positive-int, RelayInterface>
+     */
+    private array $seqToRelayMap = [];
+
+    /**
+     * Map of seq to response Frame
+     * Should only really need to be used in cases of high amounts of traffic
+     *
+     * @var array<positive-int, Frame>
+     */
+    private array $asyncResponseBuffer = [];
+
+    public function __construct(
+        /** @var RelayInterface[] $relays */
+        array          $relays,
+        CodecInterface $codec = new JsonCodec()
+    )
+    {
+        $this->freeRelays = $relays;
+        parent::__construct($codec);
+    }
+
+    public static function create(string $connection, int $count = 50, CodecInterface $codec = new JsonCodec()): self
+    {
+        assert($count > 0);
+        $relays = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            $relays[] = Relay::create($connection);
+            if ($relays[$i] instanceof SocketRelay) {
+                // Force connect
+                $relays[$i]->connect();
+            }
+        }
+
+        return new self($relays, $codec);
+    }
+
+
+    public function call(string $method, mixed $payload, mixed $options = null): mixed
+    {
+        // Avoid pushing and popping if we can
+        if (count($this->freeRelays) > 0) {
+            $relay = $this->freeRelays[0];
+        } else {
+            $relay = $this->getNextFreeRelay();
+            $this->freeRelays[] = $relay;
+        }
+
+        $relay->send($this->packFrame($method, $payload));
+
+        // wait for the frame confirmation
+        $frame = $relay->waitFrame();
+
+        if (count($frame->options) !== 2) {
+            throw new RPCException('Invalid RPC frame, options missing');
+        }
+
+        if ($frame->options[0] !== self::$seq) {
+            throw new RPCException('Invalid RPC frame, sequence mismatch');
+        }
+
+        self::$seq++;
+
+        return $this->decodeResponse($frame, $relay, $options);
+    }
+
+    public function callIgnoreResponse(string $method, mixed $payload): void
+    {
+        $relay = $this->getNextFreeRelay();
+        $relay->send($this->packFrame($method, $payload));
+        $this->occupiedRelaysIgnoreResponse[] = $relay;
+        self::$seq++;
+    }
+
+    public function callAsync(string $method, mixed $payload): int
+    {
+        $relay = $this->getNextFreeRelay();
+        $relay->send($this->packFrame($method, $payload));
+        $this->occupiedRelays[] = $relay;
+        $seq = self::$seq;
+        $this->seqToRelayMap[$seq] = $relay;
+        self::$seq++;
+        return $seq;
+    }
+
+    public function hasResponse(int $seq): bool
+    {
+        if (isset($this->asyncResponseBuffer[$seq])) {
+            return true;
+        }
+
+        if ($this->seqToRelayMap[$seq]->hasFrame()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function hasAnyResponse(array $seqs): array
+    {
+        $relays = [];
+        $relayIndexToSeq = [];
+        $seqsWithResponse = [];
+
+        foreach ($seqs as $seq) {
+            if (isset($this->asyncResponseBuffer[$seq])) {
+                $seqsWithResponse[] = $seq;
+            } elseif (isset($this->seqToRelayMap[$seq])) {
+                $relays[] = $this->seqToRelayMap[$seq];
+                $relayIndexToSeq[count($relays) - 1] = $seq;
+            }
+        }
+
+        $index = MultiRelayHelper::findRelayWithMessage($relays);
+
+        if ($index === false) {
+            return $seqsWithResponse;
+        }
+
+        if (!is_array($index)) {
+            $index = [$index];
+        }
+
+        return [...$seqsWithResponse, array_map(fn($in) => $relayIndexToSeq[$in], $index)];
+    }
+
+    public function getResponse(int $seq, mixed $options = null): mixed
+    {
+        if (($relay = $this->seqToRelayMap[$seq] ?? null) !== null) {
+            if (($frame = $this->asyncResponseBuffer[$seq] ?? null) !== null) {
+                unset($this->asyncResponseBuffer[$seq]);
+                /**
+                 * We can assume through @see MultiRPC::getNextFreeRelay() that a relay whose response is already
+                 * in this buffer has also been added to freeRelays (or is otherwise occupied).
+                 * Thus we only re-add (and do so without searching for it first) if we don't have the response yet.
+                 */
+            } else {
+                $frame = $relay->waitFrame();
+                if (($index = array_search($relay, $this->occupiedRelays, true)) !== false) {
+                    $this->freeRelays[] = array_slice($this->occupiedRelays, $index, 1)[0];
+                }
+            }
+        } else {
+            throw new RPCException('Invalid Seq, unknown');
+        }
+
+        if (count($frame->options) !== 2) {
+            throw new RPCException('Invalid RPC frame, options missing');
+        }
+
+        if ($frame->options[0] !== $seq) {
+            throw new RPCException('Invalid RPC frame, sequence mismatch');
+        }
+
+        return $this->decodeResponse($frame, $relay, $options);
+    }
+
+    private function getNextFreeRelay(): RelayInterface
+    {
+        if (count($this->freeRelays) > 0) {
+            return array_pop($this->freeRelays);
+        }
+
+        if (count($this->occupiedRelaysIgnoreResponse) > 0) {
+            $index = MultiRelayHelper::findRelayWithMessage($this->occupiedRelaysIgnoreResponse);
+
+            // Flush all available relays
+            if (is_array($index)) {
+                $occupiedRelaysIgnoreResponse = [];
+                $indexKeyed = array_flip($index);
+                foreach ($this->occupiedRelaysIgnoreResponse as $relayIndex => $relay) {
+                    if (isset($indexKeyed[$relayIndex])) {
+                        $relay->waitFrame();
+                        $this->freeRelays[] = $relay;
+                    } else {
+                        $occupiedRelaysIgnoreResponse[] = $relay;
+                    }
+                }
+
+                $this->occupiedRelaysIgnoreResponse = $occupiedRelaysIgnoreResponse;
+                return array_pop($this->freeRelays);
+            } elseif ($index !== false) {
+                $relay = array_slice($this->occupiedRelaysIgnoreResponse, $index, 1)[0];
+                $relay->waitFrame();
+                return $relay;
+            }
+        }
+
+        if (count($this->occupiedRelays) > 0) {
+            // Check if the other relays have a free one
+            $index = MultiRelayHelper::findRelayWithMessage($this->occupiedRelays);
+
+            if ($index === false) {
+                if (count($this->occupiedRelaysIgnoreResponse) > 0) {
+                    // Wait for an ignore-response relay to become free (the oldest since it makes the most sense)
+                    $relay = array_shift($this->occupiedRelaysIgnoreResponse);
+                    $relay->waitFrame();
+                    return $relay;
+                } else {
+                    // Use the oldest occupied relay for this instead
+                    $index = 0;
+                }
+            }
+
+            // Choose first one since it's the oldest and we don't want to flush all occupied relays
+            if (is_array($index)) {
+                $index = $index[0];
+            }
+
+            // Put response into buffer
+            $relay = array_slice($this->occupiedRelays, $index, 1)[0];
+            $frame = $relay->waitFrame();
+
+            if (count($frame->options) === 2) {
+                $responseSeq = $frame->options[0];
+                $this->asyncResponseBuffer[$responseSeq] = $frame;
+            }
+
+            return $relay;
+        }
+
+        throw new RuntimeException("No relays???");
+    }
+}

--- a/src/RPC/MultiRPC.php
+++ b/src/RPC/MultiRPC.php
@@ -56,7 +56,7 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
     private int $asyncBufferThreshold = self::DEFAULT_BUFFER_THRESHOLD;
 
     /**
-     * @param array<int, RelayInterface> $relays
+     * @param array<int, ConnectedRelayInterface> $relays
      */
     public function __construct(
         array $relays,
@@ -116,7 +116,9 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
         $relays = [];
 
         for ($i = 0; $i < $count; $i++) {
-            $relays[] = Relay::create($connection);
+            $relay = Relay::create($connection);
+            assert($relay instanceof ConnectedRelayInterface);
+            $relays[] = $relay;
         }
 
         return new self($relays, $asyncBufferThreshold, $codec);

--- a/src/RPC/MultiRPC.php
+++ b/src/RPC/MultiRPC.php
@@ -236,7 +236,7 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
 
     public function getResponse(int $seq, mixed $options = null): mixed
     {
-        $relay = $this->seqToRelayMap[$seq] ?? throw new RPCException('Invalid seq, unknown');
+        $relay = $this->seqToRelayMap[$seq] ?? throw new RPCException('Invalid sequence number. This may occur if the number was already used, the buffers were flushed due to insufficient getResponse calling, or with a plain inccorect number. Please check your code.');
         unset($this->seqToRelayMap[$seq]);
 
         if (($frame = $this->getResponseFromBuffer($seq)) !== null) {
@@ -279,7 +279,7 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
 
         // Make sure we have relays for all $seqs, otherwise something went wrong
         if (count($seqsToRelays) !== count($seqsKeyed)) {
-            throw new RPCException("Invalid seq, unknown");
+            throw new RPCException("Invalid sequence number. This may occur if the number was already used, the buffers were flushed due to insufficient getResponse calling, or with a plain inccorect number. Please check your code.");
         }
 
         $timeoutInMicroseconds = 0;
@@ -293,7 +293,7 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
                 if ($this->checkAllOccupiedRelaysStillConnected()) {
                     // Check if we've lost a relay we were waiting on, if so we need to quit since something is wrong.
                     if (count(array_diff_key($seqsToRelays, $this->occupiedRelays)) > 0) {
-                        throw new RPCException("Invalid seq, unknown");
+                        throw new RPCException("Invalid sequence number. This may occur if the number was already used, the buffers were flushed due to insufficient getResponse calling, or with a plain inccorect number. Please check your code.");
                     }
                 }
                 continue;

--- a/src/RPC/RPC.php
+++ b/src/RPC/RPC.php
@@ -16,8 +16,7 @@ class RPC extends AbstractRPC
     public function __construct(
         private readonly RelayInterface $relay,
         CodecInterface          $codec = new JsonCodec(),
-    )
-    {
+    ) {
         parent::__construct($codec);
     }
 

--- a/src/RPC/RPCInterface.php
+++ b/src/RPC/RPCInterface.php
@@ -26,7 +26,7 @@ interface RPCInterface
     public function withCodec(CodecInterface $codec): self;
 
     /**
-     * Invoke remove RoadRunner service method using given payload (free form).
+     * Invoke remote RoadRunner service method using given payload (free form).
      *
      * @param non-empty-string $method
      *

--- a/src/SocketRelay.php
+++ b/src/SocketRelay.php
@@ -110,6 +110,12 @@ class SocketRelay extends Relay implements Stringable
         return "unix://{$this->address}";
     }
 
+    public function __clone()
+    {
+        // Remove reference to socket on clone
+        $this->socket = null;
+    }
+
     public function getAddress(): string
     {
         return $this->address;

--- a/src/SocketRelay.php
+++ b/src/SocketRelay.php
@@ -38,7 +38,12 @@ class SocketRelay extends Relay implements Stringable
     /** @var PortType */
     private readonly ?int $port;
     private readonly SocketType $type;
-    private ?Socket $socket = null;
+    /**
+     * @internal
+     * This isn't really ideal but there's no easy way since we need access to the underlying socket
+     * to do a socket_select across multiple SocketRelays.
+     */
+    public ?Socket $socket = null;
 
     /**
      * Example:

--- a/src/SocketRelay.php
+++ b/src/SocketRelay.php
@@ -225,7 +225,6 @@ class SocketRelay extends Relay implements Stringable, ConnectedRelayInterface
      * @param int<0, max> $timeout Timeout between reconnections in microseconds.
      *
      * @throws RelayException
-     * @throws \Error When sockets are used in unsupported environment.
      */
     public function connect(int $retries = self::RECONNECT_RETRIES, int $timeout = self::RECONNECT_TIMEOUT): bool
     {

--- a/src/SocketRelay.php
+++ b/src/SocketRelay.php
@@ -24,7 +24,7 @@ use Stringable;
  *
  * @psalm-suppress DeprecatedInterface
  */
-class SocketRelay extends Relay implements Stringable
+class SocketRelay extends Relay implements Stringable, ConnectedRelayInterface
 {
     final public const RECONNECT_RETRIES = 10;
     final public const RECONNECT_TIMEOUT = 100;

--- a/src/StreamRelay.php
+++ b/src/StreamRelay.php
@@ -22,8 +22,11 @@ class StreamRelay extends Relay implements BlockingRelayInterface
 {
     /**
      * @var resource
+     * @internal
+     * This isn't really ideal but there's no easy way since we need access to the underlying stream
+     * to do a stream_select across multiple StreamRelays.
      */
-    private $in;
+    public $in;
 
     /**
      * @var resource

--- a/tests/Goridge/MsgPackMultiRPCTest.php
+++ b/tests/Goridge/MsgPackMultiRPCTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goridge;
+
+use Exception;
+use Spiral\Goridge\RPC\Codec\MsgpackCodec;
+use Spiral\Goridge\RPC\Exception\ServiceException;
+use Spiral\Goridge\RPC\MultiRPC;
+
+class MsgPackMultiRPCTest extends \Spiral\Goridge\Tests\MultiRPC
+{
+    /**
+     * @throws Exception
+     */
+    public function testJsonException(): void
+    {
+        $this->expectException(ServiceException::class);
+
+        $conn = $this->makeRPC();
+
+        $conn->call('Service.Process', random_bytes(256));
+    }
+
+    public function testJsonExceptionAsync(): void
+    {
+        $conn = $this->makeRPC();
+        $id = $conn->callAsync('Service.Process', random_bytes(256));
+        $this->expectException(ServiceException::class);
+        $conn->getResponse($id);
+    }
+
+    public function testJsonExceptionNotThrownWithIgnoreResponse(): void
+    {
+        $conn = $this->makeRPC();
+        $conn->callIgnoreResponse('Service.Process', random_bytes(256));
+
+        $this->forceFlushRpc($conn);
+    }
+
+
+    /**
+     * @return MultiRPC
+     */
+    protected function makeRPC(): MultiRPC
+    {
+        return parent::makeRPC()->withCodec(new MsgpackCodec());
+    }
+}

--- a/tests/Goridge/MsgPackMultiRPCTest.php
+++ b/tests/Goridge/MsgPackMultiRPCTest.php
@@ -43,8 +43,8 @@ class MsgPackMultiRPCTest extends \Spiral\Goridge\Tests\MultiRPC
     /**
      * @return MultiRPC
      */
-    protected function makeRPC(): MultiRPC
+    protected function makeRPC(int $count = 10): MultiRPC
     {
-        return parent::makeRPC()->withCodec(new MsgpackCodec());
+        return parent::makeRPC($count)->withCodec(new MsgpackCodec());
     }
 }

--- a/tests/Goridge/MultiRPC.php
+++ b/tests/Goridge/MultiRPC.php
@@ -447,7 +447,7 @@ abstract class MultiRPC extends TestCase
         $this->assertSame('pong', $this->rpc->getResponse($id));
         $this->assertFreeRelaysCorrectNumber($this->rpc);
         $this->expectException(RPCException::class);
-        $this->expectExceptionMessage('Invalid seq, unknown');
+        $this->expectExceptionMessage('Invalid sequence number. This may occur if the number was already used, the buffers were flushed due to insufficient getResponse calling, or with a plain inccorect number. Please check your code.');
         $this->assertSame('pong', $this->rpc->getResponse($id));
     }
 
@@ -543,7 +543,7 @@ abstract class MultiRPC extends TestCase
 
         if ($discovered) {
             $this->expectException(RPCException::class);
-            $this->expectExceptionMessage('Invalid seq, unknown');
+            $this->expectExceptionMessage('Invalid sequence number. This may occur if the number was already used, the buffers were flushed due to insufficient getResponse calling, or with a plain inccorect number. Please check your code.');
         } else {
             $this->expectException(TransportException::class);
             $this->expectExceptionMessage('Unable to read payload from the stream');
@@ -581,7 +581,7 @@ abstract class MultiRPC extends TestCase
         }
 
         $this->expectException(RPCException::class);
-        $this->expectExceptionMessage('Invalid seq, unknown');
+        $this->expectExceptionMessage('Invalid sequence number. This may occur if the number was already used, the buffers were flushed due to insufficient getResponse calling, or with a plain inccorect number. Please check your code.');
         $this->rpc->getResponse($id);
     }
 
@@ -624,7 +624,7 @@ abstract class MultiRPC extends TestCase
 
 
             $this->expectException(RPCException::class);
-            $this->expectExceptionMessage('Invalid seq, unknown');
+            $this->expectExceptionMessage('Invalid sequence number. This may occur if the number was already used, the buffers were flushed due to insufficient getResponse calling, or with a plain inccorect number. Please check your code.');
         }
 
         $this->expectException(TransportException::class);
@@ -646,7 +646,7 @@ abstract class MultiRPC extends TestCase
         }
 
         $this->expectException(RPCException::class);
-        $this->expectExceptionMessage('Invalid seq, unknown');
+        $this->expectExceptionMessage('Invalid sequence number. This may occur if the number was already used, the buffers were flushed due to insufficient getResponse calling, or with a plain inccorect number. Please check your code.');
         foreach ($this->rpc->getResponses($ids) as $response) {
             $this->assertSame('pong', $response);
         }

--- a/tests/Goridge/MultiRPC.php
+++ b/tests/Goridge/MultiRPC.php
@@ -433,13 +433,27 @@ abstract class MultiRPC extends TestCase
 
     public function testCannotGetSameResponseTwice(): void
     {
-
         $id = $this->rpc->callAsync('Service.Ping', 'ping');
         $this->assertSame('pong', $this->rpc->getResponse($id));
         $this->assertFreeRelaysCorrectNumber($this->rpc);
         $this->expectException(RPCException::class);
         $this->expectExceptionMessage('Invalid Seq, unknown');
         $this->assertSame('pong', $this->rpc->getResponse($id));
+    }
+
+    public function testCanCallMoreTimesThanRelays(): void
+    {
+        $ids = [];
+
+        for ($i = 0; $i < 50; $i++) {
+            $ids[] = $this->rpc->callAsync('Service.Ping', 'ping');
+        }
+
+        foreach ($this->rpc->getResponses($ids) as $response) {
+            $this->assertSame('pong', $response);
+        }
+
+        $this->assertFreeRelaysCorrectNumber($this->rpc);
     }
 
     protected function setUp(): void

--- a/tests/Goridge/MultiRPC.php
+++ b/tests/Goridge/MultiRPC.php
@@ -9,6 +9,7 @@ use ReflectionMethod;
 use ReflectionProperty;
 use Spiral\Goridge\Exception\TransportException;
 use Spiral\Goridge\RelayInterface;
+use Spiral\Goridge\RPC\Codec\MsgpackCodec;
 use Spiral\Goridge\RPC\Codec\RawCodec;
 use Spiral\Goridge\RPC\Exception\CodecException;
 use Spiral\Goridge\RPC\Exception\RPCException;
@@ -647,6 +648,18 @@ abstract class MultiRPC extends TestCase
         foreach ($this->rpc->getResponses($ids) as $response) {
             $this->assertSame('pong', $response);
         }
+    }
+
+    /**
+     * This test checks whether relays are cloned correctly, or if they get shared between the cloned instances.
+     * Without cloning them explicitly they get shared and thus, when one RPC gets called, the freeRelays array
+     * in the other RPC stays the same, making it reuse the just-used and still occupied relay.
+     */
+    public function testHandleCloneCorrectly(): void
+    {
+        $clonedRpc = $this->rpc->withCodec(new MsgpackCodec());
+        $clonedRpc->callIgnoreResponse('Service.Ping', 'ping');
+        $this->assertSame('pong', $this->rpc->call('Service.Ping', 'ping'));
     }
 
     protected function setUp(): void

--- a/tests/Goridge/MultiRPC.php
+++ b/tests/Goridge/MultiRPC.php
@@ -686,7 +686,7 @@ abstract class MultiRPC extends TestCase
 
     public function testAllowsOnlySockets(): void{
         $this->expectException(RPCException::class);
-        $this->expectExceptionMessage("MultiRPC can only be used with sockets, no pipes allowed");
+        $this->expectExceptionMessage("MultiRPC can only be used with SocketRelay");
         $this->rpc = new GoridgeMultiRPC([new StreamRelay(STDIN, STDOUT)]);
     }
 

--- a/tests/Goridge/MultiRPC.php
+++ b/tests/Goridge/MultiRPC.php
@@ -1,0 +1,495 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goridge;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Goridge\RelayInterface;
+use Spiral\Goridge\RPC\Codec\RawCodec;
+use Spiral\Goridge\RPC\Exception\CodecException;
+use Spiral\Goridge\RPC\Exception\RPCException;
+use Spiral\Goridge\RPC\Exception\ServiceException;
+use Spiral\Goridge\RPC\MultiRPC as GoridgeMultiRPC;
+use Spiral\Goridge\SocketRelay;
+use Spiral\Goridge\SocketType;
+
+abstract class MultiRPC extends TestCase
+{
+    public const GO_APP = 'server';
+    public const SOCK_ADDR = '127.0.0.1';
+    public const SOCK_PORT = 7079;
+    public const SOCK_TYPE = SocketType::TCP;
+
+    public function testManualConnect(): void
+    {
+        $relays = [];
+        for ($i = 0; $i < 10; $i++) {
+            $relays[] = $this->makeRelay();
+        }
+        /** @var SocketRelay $relay */
+        $relay = $relays[0];
+        $conn = new GoridgeMultiRPC($relays);
+
+        $this->assertFalse($relay->isConnected());
+
+        $relay->connect();
+        $this->assertTrue($relay->isConnected());
+
+        $this->assertSame('pong', $conn->call('Service.Ping', 'ping'));
+        $this->assertTrue($relay->isConnected());
+
+        $conn->preConnectRelays();
+        foreach ($relays as $relay) {
+            $this->assertTrue($relay->isConnected());
+        }
+    }
+
+    public function testReconnect(): void
+    {
+        /** @var SocketRelay $relay */
+        $relay = $this->makeRelay();
+        $conn = new GoridgeMultiRPC([$relay]);
+
+        $this->assertFalse($relay->isConnected());
+
+        $this->assertSame('pong', $conn->call('Service.Ping', 'ping'));
+        $this->assertTrue($relay->isConnected());
+
+        $relay->close();
+        $this->assertFalse($relay->isConnected());
+
+        $this->assertSame('pong', $conn->call('Service.Ping', 'ping'));
+        $this->assertTrue($relay->isConnected());
+    }
+
+    public function testPingPong(): void
+    {
+        $conn = $this->makeRPC();
+        $this->assertSame('pong', $conn->call('Service.Ping', 'ping'));
+    }
+
+    public function testPingPongAsync(): void
+    {
+        $conn = $this->makeRPC();
+        $id = $conn->callAsync('Service.Ping', 'ping');
+        $this->assertSame('pong', $conn->getResponse($id));
+    }
+
+    public function testPrefixPingPong(): void
+    {
+        $conn = $this->makeRPC()->withServicePrefix('Service');
+        $this->assertSame('pong', $conn->call('Ping', 'ping'));
+    }
+
+    public function testPrefixPingPongAsync(): void
+    {
+        $conn = $this->makeRPC()->withServicePrefix('Service');
+        $id = $conn->callAsync('Ping', 'ping');
+        $this->assertSame('pong', $conn->getResponse($id));
+    }
+
+    public function testPingNull(): void
+    {
+        $conn = $this->makeRPC();
+        $this->assertSame('', $conn->call('Service.Ping', 'not-ping'));
+    }
+
+    public function testPingNullAsync(): void
+    {
+        $conn = $this->makeRPC();
+        $id = $conn->callAsync('Service.Ping', 'not-ping');
+        $this->assertSame('', $conn->getResponse($id));
+    }
+
+    public function testNegate(): void
+    {
+        $conn = $this->makeRPC();
+        $this->assertSame(-10, $conn->call('Service.Negate', 10));
+    }
+
+    public function testNegateAsync(): void
+    {
+        $conn = $this->makeRPC();
+        $id = $conn->callAsync('Service.Negate', 10);
+        $this->assertSame(-10, $conn->getResponse($id));
+    }
+
+    public function testNegateNegative(): void
+    {
+        $conn = $this->makeRPC();
+        $this->assertSame(10, $conn->call('Service.Negate', -10));
+    }
+
+    public function testNegateNegativeAsync(): void
+    {
+        $conn = $this->makeRPC();
+        $id = $conn->callAsync('Service.Negate', -10);
+        $this->assertSame(10, $conn->getResponse($id));
+    }
+
+    public function testInvalidService(): void
+    {
+        $this->expectException(ServiceException::class);
+        $conn = $this->makeRPC()->withServicePrefix('Service2');
+        $this->assertSame('pong', $conn->call('Ping', 'ping'));
+    }
+
+    public function testInvalidServiceAsync(): void
+    {
+        $conn = $this->makeRPC()->withServicePrefix('Service2');
+        $id = $conn->callAsync('Ping', 'ping');
+        $this->expectException(ServiceException::class);
+        $this->assertSame('pong', $conn->getResponse($id));
+    }
+
+    public function testInvalidMethod(): void
+    {
+        $this->expectException(ServiceException::class);
+        $conn = $this->makeRPC()->withServicePrefix('Service');
+        $this->assertSame('pong', $conn->call('Ping2', 'ping'));
+    }
+
+    public function testInvalidMethodAsync(): void
+    {
+        $conn = $this->makeRPC()->withServicePrefix('Service');
+        $id = $conn->callAsync('Ping2', 'ping');
+        $this->expectException(ServiceException::class);
+        $this->assertSame('pong', $conn->getResponse($id));
+    }
+
+    public function testLongEcho(): void
+    {
+        $conn = $this->makeRPC();
+        $payload = base64_encode(random_bytes(65000 * 5));
+
+        $resp = $conn->call('Service.Echo', $payload);
+
+        $this->assertSame(strlen($payload), strlen($resp));
+        $this->assertSame(md5($payload), md5($resp));
+    }
+
+    public function testLongEchoAsync(): void
+    {
+        $conn = $this->makeRPC();
+        $payload = base64_encode(random_bytes(65000 * 5));
+
+        $id = $conn->callAsync('Service.Echo', $payload);
+        $resp = $conn->getResponse($id);
+
+        $this->assertSame(strlen($payload), strlen($resp));
+        $this->assertSame(md5($payload), md5($resp));
+    }
+
+    public function testConvertException(): void
+    {
+        $this->expectException(ServiceException::class);
+        $this->expectExceptionMessage('unknown Raw payload type');
+
+        $conn = $this->makeRPC();
+        $payload = base64_encode(random_bytes(65000 * 5));
+
+        $resp = $conn->withCodec(new RawCodec())->call(
+            'Service.Echo',
+            $payload
+        );
+
+        $this->assertSame(strlen($payload), strlen($resp));
+        $this->assertSame(md5($payload), md5($resp));
+    }
+
+    public function testConvertExceptionAsync(): void
+    {
+        $conn = $this->makeRPC();
+        $payload = base64_encode(random_bytes(65000 * 5));
+
+        $id = $conn->withCodec(new RawCodec())->callAsync(
+            'Service.Echo',
+            $payload
+        );
+
+        $this->expectException(ServiceException::class);
+        $this->expectExceptionMessage('unknown Raw payload type');
+
+        $resp = $conn->getResponse($id);
+
+        $this->assertSame(strlen($payload), strlen($resp));
+        $this->assertSame(md5($payload), md5($resp));
+    }
+
+
+    public function testRawBody(): void
+    {
+        $conn = $this->makeRPC();
+        $payload = random_bytes(100);
+
+        $resp = $conn->withCodec(new RawCodec())->call(
+            'Service.EchoBinary',
+            $payload
+        );
+
+        $this->assertSame(strlen($payload), strlen($resp));
+        $this->assertSame(md5($payload), md5($resp));
+    }
+
+    public function testRawBodyAsync(): void
+    {
+        $conn = $this->makeRPC();
+        $payload = random_bytes(100);
+
+        $id = $conn->withCodec(new RawCodec())->callAsync(
+            'Service.EchoBinary',
+            $payload
+        );
+        $resp = $conn->getResponse($id);
+
+        $this->assertSame(strlen($payload), strlen($resp));
+        $this->assertSame(md5($payload), md5($resp));
+    }
+
+    public function testLongRawBody(): void
+    {
+        $conn = $this->makeRPC();
+        $payload = random_bytes(65000 * 1000);
+
+        $resp = $conn->withCodec(new RawCodec())->call(
+            'Service.EchoBinary',
+            $payload
+        );
+
+        $this->assertSame(strlen($payload), strlen($resp));
+        $this->assertSame(md5($payload), md5($resp));
+    }
+
+    public function testLongRawBodyAsync(): void
+    {
+        $conn = $this->makeRPC();
+        $payload = random_bytes(65000 * 1000);
+
+        $id = $conn->withCodec(new RawCodec())->callAsync(
+            'Service.EchoBinary',
+            $payload
+        );
+        $resp = $conn->getResponse($id);
+
+        $this->assertSame(strlen($payload), strlen($resp));
+        $this->assertSame(md5($payload), md5($resp));
+    }
+
+    public function testPayload(): void
+    {
+        $conn = $this->makeRPC();
+
+        $resp = $conn->call(
+            'Service.Process',
+            [
+                'Name' => 'wolfy-j',
+                'Value' => 18
+            ]
+        );
+
+        $this->assertSame(
+            [
+                'Name' => 'WOLFY-J',
+                'Value' => -18,
+                'Keys' => null
+            ],
+            $resp
+        );
+    }
+
+    public function testPayloadAsync(): void
+    {
+        $conn = $this->makeRPC();
+
+        $id = $conn->callAsync(
+            'Service.Process',
+            [
+                'Name' => 'wolfy-j',
+                'Value' => 18
+            ]
+        );
+        $resp = $conn->getResponse($id);
+
+        $this->assertSame(
+            [
+                'Name' => 'WOLFY-J',
+                'Value' => -18,
+                'Keys' => null
+            ],
+            $resp
+        );
+    }
+
+    public function testBadPayload(): void
+    {
+        $this->expectException(ServiceException::class);
+        $this->expectExceptionMessage('unknown Raw payload type');
+
+        $conn = $this->makeRPC();
+        $conn->withCodec(new RawCodec())->call('Service.Process', 'raw');
+    }
+
+    public function testBadPayloadAsync(): void
+    {
+        $conn = $this->makeRPC();
+        $id = $conn->withCodec(new RawCodec())->callAsync('Service.Process', 'raw');
+
+        $this->expectException(ServiceException::class);
+        $this->expectExceptionMessage('unknown Raw payload type');
+        $resp = $conn->getResponse($id);
+    }
+
+    public function testPayloadWithMap(): void
+    {
+        $conn = $this->makeRPC();
+
+        $resp = $conn->call(
+            'Service.Process',
+            [
+                'Name' => 'wolfy-j',
+                'Value' => 18,
+                'Keys' => [
+                    'Key' => 'value',
+                    'Email' => 'domain'
+                ]
+            ]
+        );
+
+        $this->assertIsArray($resp['Keys']);
+        $this->assertArrayHasKey('value', $resp['Keys']);
+        $this->assertArrayHasKey('domain', $resp['Keys']);
+
+        $this->assertSame('Key', $resp['Keys']['value']);
+        $this->assertSame('Email', $resp['Keys']['domain']);
+    }
+
+    public function testPayloadWithMapAsync(): void
+    {
+        $conn = $this->makeRPC();
+
+        $id = $conn->callAsync(
+            'Service.Process',
+            [
+                'Name' => 'wolfy-j',
+                'Value' => 18,
+                'Keys' => [
+                    'Key' => 'value',
+                    'Email' => 'domain'
+                ]
+            ]
+        );
+        $resp = $conn->getResponse($id);
+
+        $this->assertIsArray($resp['Keys']);
+        $this->assertArrayHasKey('value', $resp['Keys']);
+        $this->assertArrayHasKey('domain', $resp['Keys']);
+
+        $this->assertSame('Key', $resp['Keys']['value']);
+        $this->assertSame('Email', $resp['Keys']['domain']);
+    }
+
+    public function testBrokenPayloadMap(): void
+    {
+        $conn = $this->makeRPC();
+
+        $id = $conn->callAsync(
+            'Service.Process',
+            [
+                'Name' => 'wolfy-j',
+                'Value' => 18,
+                'Keys' => 1111
+            ]
+        );
+
+        $this->expectException(ServiceException::class);
+        $resp = $conn->getResponse($id);
+    }
+
+    public function testJsonException(): void
+    {
+        $this->expectException(CodecException::class);
+
+        $conn = $this->makeRPC();
+
+        $conn->call('Service.Process', random_bytes(256));
+    }
+
+    public function testJsonExceptionAsync(): void
+    {
+        $this->expectException(CodecException::class);
+
+        $conn = $this->makeRPC();
+
+        $conn->callAsync('Service.Process', random_bytes(256));
+    }
+
+    public function testJsonExceptionIgnoreResponse(): void
+    {
+        $this->expectException(CodecException::class);
+
+        $conn = $this->makeRPC();
+
+        $conn->callIgnoreResponse('Service.Process', random_bytes(256));
+    }
+
+    public function testSleepEcho(): void
+    {
+        $conn = $this->makeRPC();
+        $time = hrtime(true);
+        $this->assertSame('Hello', $conn->call('Service.SleepEcho', 'Hello'));
+        // sleep is 100ms, so we check if we are further along than 100ms
+        $this->assertGreaterThanOrEqual($time + (100 * 1e6), hrtime(true));
+    }
+
+    public function testSleepEchoAsync(): void
+    {
+        $conn = $this->makeRPC();
+        $time = hrtime(true);
+        $id = $conn->callAsync('Service.SleepEcho', 'Hello');
+        // hrtime is in nanoseconds, and at most expect 100 microseconds (sleep is 100ms)
+        $this->assertLessThanOrEqual($time + (100 * 1e3), hrtime(true));
+        $this->assertFalse($conn->hasResponse($id));
+        $this->assertSame('Hello', $conn->getResponse($id));
+        // sleep is 100ms, so we check if we are further along than 100ms
+        $this->assertGreaterThanOrEqual($time + (100 * 1e6), hrtime(true));
+    }
+
+    public function testSleepEchoIgnoreResponse(): void
+    {
+        $conn = $this->makeRPC();
+        $time = hrtime(true);
+        $conn->callIgnoreResponse('Service.SleepEcho', 'Hello');
+        // hrtime is in nanoseconds, and at most expect 100 microseconds (sleep is 100ms)
+        $this->assertLessThanOrEqual($time + (100 * 1e3), hrtime(true));
+    }
+
+    public function testCannotGetSameResponseTwice(): void
+    {
+        $conn = $this->makeRPC();
+        $id = $conn->callAsync('Service.Ping', 'ping');
+        $this->assertSame('pong', $conn->getResponse($id));
+        $this->expectException(RPCException::class);
+        $this->expectExceptionMessage('Invalid Seq, unknown');
+    }
+
+    /**
+     * @return GoridgeMultiRPC
+     */
+    protected function makeRPC(): GoridgeMultiRPC
+    {
+        $relays = [];
+        for ($i = 0; $i < 10; $i++) {
+            $relays[] = $this->makeRelay();
+        }
+        return new GoridgeMultiRPC($relays);
+    }
+
+    /**
+     * @return RelayInterface
+     */
+    protected function makeRelay(): RelayInterface
+    {
+        return new SocketRelay(static::SOCK_ADDR, static::SOCK_PORT, static::SOCK_TYPE);
+    }
+}

--- a/tests/Goridge/MultiRelayHelperTest.php
+++ b/tests/Goridge/MultiRelayHelperTest.php
@@ -14,4 +14,14 @@ class MultiRelayHelperTest extends TestCase
         // No message available on STDIN, aka a read would block, so this returns false
         $this->assertFalse(MultiRelayHelper::findRelayWithMessage($relays));
     }
+
+    public function testSupportsReadingFromStreamRelay(): void
+    {
+        $stream = fopen('php://temp', 'rw+');
+        fwrite($stream, 'Hello');
+        fseek($stream, 0);
+        $relays = [new StreamRelay($stream, STDOUT)];
+        $this->assertCount(1, MultiRelayHelper::findRelayWithMessage($relays));
+        fclose($stream);
+    }
 }

--- a/tests/Goridge/MultiRelayHelperTest.php
+++ b/tests/Goridge/MultiRelayHelperTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Goridge;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Goridge\MultiRelayHelper;
+use Spiral\Goridge\StreamRelay;
+
+class MultiRelayHelperTest extends TestCase
+{
+    public function testSupportsStreamRelay(): void
+    {
+        $relays = [new StreamRelay(STDIN, STDOUT), new StreamRelay(STDIN, STDERR)];
+        // No message available on STDIN, aka a read would block, so this returns false
+        $this->assertFalse(MultiRelayHelper::findRelayWithMessage($relays));
+    }
+}

--- a/tests/Goridge/TCPMultiRPCTest.php
+++ b/tests/Goridge/TCPMultiRPCTest.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Spiral\Goridge\Tests;
+namespace Goridge;
 
 use Spiral\Goridge\SocketType;
+use Spiral\Goridge\Tests\MultiRPC;
 
-class TPCRPCTest extends RPC
+class TCPMultiRPCTest extends MultiRPC
 {
     public const SOCK_ADDR = '127.0.0.1';
     public const SOCK_PORT = 7079;

--- a/tests/Goridge/TCPRPCTest.php
+++ b/tests/Goridge/TCPRPCTest.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Goridge;
+namespace Spiral\Goridge\Tests;
 
 use Spiral\Goridge\SocketType;
-use Spiral\Goridge\Tests\MultiRPC;
 
-class TPCMultiRPCTest extends MultiRPC
+class TCPRPCTest extends RPC
 {
     public const SOCK_ADDR = '127.0.0.1';
     public const SOCK_PORT = 7079;

--- a/tests/Goridge/TPCMultiRPCTest.php
+++ b/tests/Goridge/TPCMultiRPCTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Goridge;
+
+use Spiral\Goridge\SocketType;
+use Spiral\Goridge\Tests\MultiRPC;
+
+class TPCMultiRPCTest extends MultiRPC
+{
+    public const SOCK_ADDR = '127.0.0.1';
+    public const SOCK_PORT = 7079;
+    public const SOCK_TYPE = SocketType::TCP;
+}

--- a/tests/test-server/server.go
+++ b/tests/test-server/server.go
@@ -5,6 +5,7 @@ import (
 	"net/rpc"
 	"os"
 	"strings"
+	"time"
 
 	goridgeRpc "github.com/spiral/goridge/v3/pkg/rpc"
 )
@@ -59,6 +60,13 @@ func (s *Service) EchoBinary(msg []byte, out *[]byte) error {
 	*out = append(*out, msg...)
 
 	return nil
+}
+
+// SleepEcho sleeps for 100ms before returning incoming message
+func (s *Service) SleepEcho(msg string, r *string) error {
+    time.Sleep(100 * time.Millisecond)
+    *r = msg
+    return nil
 }
 
 func main() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️ TODO please update "Other Features" section in CHANGELOG.md file
| Issues        | https://github.com/orgs/roadrunner-server/discussions/1850 
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features --> TODO?

Implements an "Async" RPC Interface and Implementation using multiple relays to effectively offer non-blocking IO in regards to the Roadrunner communication.

As discussed in the linked discussion, there's a (small but signifcant) delay in the RPC communication to Roadrunner that *can* have an impact on a service. In my case the service had a nominal response time of ~2ms, went up to 3ms with metric collection and also had a 2ms `kernel.terminate` listener to collect further metrics, so all in all was busy for ~5ms with only ~2ms spent on the actual request->response cycle.

As a fix I propose an "async" implementation of the RPC interface. I don't really like calling it async, because it doesn't offer the same versatility as a proper async implementation, but it changes the control flow and thus qualifies for that name, I guess.
The interface has 3 significant new methods as well as a few supporting changes in other code:
- callIgnoreResponse => Calls a Roadrunner method but doesn't wait for the response and ignores it if it's received. This is intended for "best-effort" areas such as Metrics collection, where it is generally accepted if some Metrics get lost on the way
- callAsync => Calls a Roadrunner method and tracks the response rather than wait for it. The response can then be received with...
- getResponse => Gets and if needed waits for a response from a previous call to callAsync. The request/response is tracked with the already used $seq. The implementation keeps the response in the socket buffer as long as possible until it's needed to reduce unnecessary delays
- The supporting methods `hasResponse` and `hasAnyResponse` just check if a response has been received

**Results**
I've measured the impact in a testcase using the same repro used in the discussion. The results are the following:
- Sync Metrics Call: 1.228ms
- AlwaysIgnoreResponseRPC (from the repro) Call: 0.1366ms
- MultiRPC Call (this change): 0.1399ms
As you can see the "good" implementation (this change) is within the normal deviation of the always-ignore implementation and offers an improvement ~10x performance. I've been using a (slightly modified) implementation of this in the aforementioned production service and could cut down the time spent collecting metrics from a total of 3ms to just 0,2ms, with a min/max of respectively 0.1ms and 0.3ms.

I've also added a change (PR following) in roadrunner-kv that uses the `callAsync` method to implement a `setAsync` function. The results so far are promising. With a follow-up check on whether the `kv.Set` call was successful, the async implementation is significantly faster:

- "SyncKVImpactCacheStartup": "56.2324ms"
- "SyncKVImpactNewItem": "0.5328ms"
- "SyncKVImpactExistingItemSameValue: "0.2113ms"
- "SyncKVImpactExistingItemNewValue": "0.2006ms"
- "AsyncKVImpactCacheStartup": "21.7821ms"
- "AsyncKVImpactNewItem": "0.1146ms"

Full results for the Metrics calls:
````json
{
    "Base": {
        "Max": "0.2063ms",
        "Min": "0.0954ms",
        "Avg": "0.1228ms",
        "Total": "1.228ms"
    },
    "AlwaysIgnoreResponseRPC": {
        "Max": "0.0537ms",
        "Min": "0.0069ms",
        "Avg": "0.01366ms",
        "Total": "0.1366ms"
    },
    "MultiRPC": {
        "Max": "0.0714ms",
        "Min": "0.0061ms",
        "Avg": "0.01399ms",
        "Total": "0.1399ms"
    }
}
````


**Considerations**
- The whole implementation is "opt-in", which can also be seen in my two follow-up PRs ([#1](https://github.com/roadrunner-php/metrics/pull/13) and [#2](https://github.com/roadrunner-php/kv/pull/36)). I didn't want to force it in case someone depends on the existing implementation. It makes some of the code look a bit messy due to having to support both code paths but I think it's the better solution. I'm open to change it though if you disagree.
- I had to "open" two previously private fields in the Relay implementations to make more effective use of `socket_select` and `stream_select`. I've commented it as well as marked them with `@internal` but it's definitely not ideal.
- ~The overflow response buffer currently has no upper limit and thus it's somewhat easy to get a memory leak here. I could add a check in `callAsync` to see if the response buffer is above a certain limit (1000?) and if so flush it. I'll probably do so when adding the tests.~ Implemented a flush at 1000 entries (realistically the most a normal application should ever see is maybe ~50) -- I've upped this to 10_000 entries because in testing in particular Doctrine caches get hammered extremely hard and 1_000 is not enough.

**TODO**
- ~I have glanced at the tests in this repo and will try to implement a few for this change if you've given me the go-ahead with the current implementation.~ Added a number of tests
- Add a Changelog.md entry
- Add documentation for this (?)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced multi-relay functionality for enhanced message and relay management.
    - Added asynchronous RPC communication capabilities over multiple relays.
    - Improved RPC functionality with new methods and class structures for more efficient communication and coding practices.
- **Bug Fixes**
    - Corrected a typo in RPCInterface method description for clarity.
- **Refactor**
    - Updated the RPC class to extend from `AbstractRPC` with various method and property adjustments for streamlined operation.
    - Modified visibility of certain properties in `SocketRelay` and `StreamRelay` to public, with added documentation for these changes.
- **Tests**
    - Added a comprehensive test suite for multiple RPC interactions, including exception handling and asynchronous calls.
    - Introduced test cases specifically for MsgPack and TCP communication in the MultiRPC context.
- **Documentation**
    - Enhanced internal documentation to explain visibility changes in relay properties.
- **Chores**
    - Implemented minor server-side enhancements, including a new `SleepEcho` function for testing purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->