### PR TITLE
fix(typo): typo in `phpdoc Relay::create` method

### DIFF
--- a/src/Relay.php
+++ b/src/Relay.php
@@ -19,7 +19,7 @@ abstract class Relay implements RelayInterface
      * Example:
      *
      * Relay::create("pipes");
-     * Relay::create("tpc://localhost:6001");
+     * Relay::create("tcp://localhost:6001");
      *
      *
      * @param non-empty-string $connection


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->

<!-- Please, replace this notice by a short description of your feature/bugfix.
This will help people understand your PR and can be used as a start for the documentation. -->
Fix typo in phpdoc Relay::create method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the protocol string for relay connections, ensuring reliable connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->