### PR TITLE
Fix "Undefined array key 0" warning in MultiRPC constructor

### DIFF
--- a/src/RPC/MultiRPC.php
+++ b/src/RPC/MultiRPC.php
@@ -77,8 +77,6 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
             }
 
             // Check if the existing relays (if any) and the new relays are of the same type.
-            // Note: self::$freeRelays is not guaranteed to be 0-indexed — entries are removed
-            // via unset() in occupy*() and PHP keeps the highest key ever used on append.
             if (\count(self::$freeRelays) > 0) {
                 $existingRelay = self::$freeRelays[\array_key_first(self::$freeRelays)];
             } elseif (\count(self::$occupiedRelays) > 0) {

--- a/src/RPC/MultiRPC.php
+++ b/src/RPC/MultiRPC.php
@@ -77,8 +77,10 @@ class MultiRPC extends AbstractRPC implements AsyncRPCInterface
             }
 
             // Check if the existing relays (if any) and the new relays are of the same type.
+            // Note: self::$freeRelays is not guaranteed to be 0-indexed — entries are removed
+            // via unset() in occupy*() and PHP keeps the highest key ever used on append.
             if (\count(self::$freeRelays) > 0) {
-                $existingRelay = self::$freeRelays[0];
+                $existingRelay = self::$freeRelays[\array_key_first(self::$freeRelays)];
             } elseif (\count(self::$occupiedRelays) > 0) {
                 $existingRelay = self::$occupiedRelays[\array_key_first(self::$occupiedRelays)];
             } else {


### PR DESCRIPTION
`self::$freeRelays` is not guaranteed to be 0-indexed: entries are removed via `unset(self::$freeRelays[$relayIndex])` in `occupyRelay()` and `occupyRelayAsync()` (lines 171, 194), and PHP's auto-increment retains the highest key ever used when appending. After enough churn in a long-running worker (e.g. RoadRunner), the static array can end up with keys like `[1 => ..., 3 => ...]` — `count() > 0` holds, but `self::$freeRelays[0]` raises `Warning: Undefined array key 0`.

Switch to `array_key_first()`, mirroring the `$occupiedRelays` branch two lines below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay selection mechanism to handle non-standard array indexing, ensuring proper relay assignment in all scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roadrunner-php/goridge/pull/36)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->